### PR TITLE
feat: Add API Key authentication for Dhru Fusion integration

### DIFF
--- a/src/app/api/dhru/route.ts
+++ b/src/app/api/dhru/route.ts
@@ -1,0 +1,217 @@
+/**
+ * Dhru Fusion compatible endpoint
+ * URL to set in Dhru Fusion: https://your-domain.vercel.app/api/dhru
+ *
+ * Env vars required:
+ *   DHRU_API_KEY   - the API Key you set in Dhru Fusion
+ *   DHRU_USERNAME  - the Username you set in Dhru Fusion
+ */
+
+import type { NextRequest } from "next/server";
+import {
+    lookupCURPINMobig,
+    lookupCURPInABIB,
+    lookupCURPInAltanMVNO,
+    lookupCURPInATT,
+    lookupCURPInBeneleit,
+    lookupCURPInDialo,
+    lookupCURPInIENTC,
+    lookupCURPInLogisticaACN,
+    lookupCURPInMirlo,
+    lookupCURPInTelcel,
+    lookupCURPInVinculatulinea,
+    loookupCURPInVirginMobile,
+} from "@/lib/providers";
+import { validateCURP } from "@/lib/providers/curp";
+import { stripCURPs } from "@/lib/sanitize";
+
+// In-memory order store (resets on cold start, sufficient for Dhru polling)
+const orders = new Map<
+    string,
+{
+      status: "pending" | "inprogress" | "completed" | "error";
+      result?: string;
+      createdAt: number;
+}
+  >();
+
+// Cleanup orders older than 1 hour
+setInterval(() => {
+    const cutoff = Date.now() - 60 * 60_000;
+    for (const [id, order] of orders) {
+          if (order.createdAt < cutoff) orders.delete(id);
+    }
+}, 10 * 60_000).unref();
+
+function validateAuth(apiKey: string | null, username: string | null): boolean {
+    const validKey = process.env.DHRU_API_KEY ?? "";
+    const validUser = process.env.DHRU_USERNAME ?? "";
+    if (!validKey || !validUser) return false;
+    return apiKey === validKey && username === validUser;
+}
+
+async function runLookup(curp: string): Promise<string> {
+    const providers = [
+      { provider: "AT&T", fn: lookupCURPInATT },
+      { provider: "Telcel", fn: lookupCURPInTelcel },
+      { provider: "Altan MVNO", fn: lookupCURPInAltanMVNO },
+      { provider: "ABIB", fn: lookupCURPInABIB },
+      { provider: "Beneleit Móvil", fn: lookupCURPInBeneleit },
+      { provider: "Dialo", fn: lookupCURPInDialo },
+      { provider: "IENTC", fn: lookupCURPInIENTC },
+      { provider: "Logistica ACN (FedeGo!, Flash Mobile, Dua)", fn: lookupCURPInLogisticaACN },
+      { provider: "Mirlo", fn: lookupCURPInMirlo },
+      { provider: "MoBig", fn: lookupCURPINMobig },
+      { provider: "Virgin Mobile", fn: loookupCURPInVirginMobile },
+      { provider: "Vinculatulinea (Freedompop/OUI/OXXO CEL/Uber Cel/AhorroCel/Chedraui Móvil/Yobi Telecom)", fn: lookupCURPInVinculatulinea },
+        ];
+
+  const results = await Promise.allSettled(
+        providers.map((p) =>
+                p.fn(curp).then(
+                          (r) => ({ provider: p.provider, lines: r.lines ?? [], error: r.error }),
+                          (e) => ({ provider: p.provider, lines: [], error: String(e?.message ?? e) }),
+                        ),
+                          ),
+      );
+
+  const lines: string[] = [];
+    const errors: string[] = [];
+
+  for (const r of results) {
+        if (r.status === "fulfilled") {
+                const val = stripCURPs(r.value) as { provider: string; lines: string[]; error?: string };
+                if (val.lines && val.lines.length > 0) {
+                          for (const line of val.lines) {
+                                      lines.push(`${val.provider}: ${line}`);
+                          }
+                }
+                if (val.error) {
+                          errors.push(`${val.provider}: ${val.error}`);
+                }
+        }
+  }
+
+  if (lines.length === 0) {
+        return `CURP: ${curp}\nNo se encontraron líneas registradas.\n\nErrores/No disponibles:\n${errors.slice(0, 5).join("\n")}`;
+  }
+
+  return `CURP: ${curp}\n\nLíneas encontradas:\n${lines.join("\n")}`;
+}
+
+async function handlePost(req: NextRequest): Promise<Response> {
+    let body: Record<string, string> = {};
+
+  const contentType = req.headers.get("content-type") ?? "";
+
+  if (contentType.includes("application/json")) {
+        body = await req.json().catch(() => ({}));
+  } else {
+        // application/x-www-form-urlencoded (default for Dhru Fusion)
+      const text = await req.text().catch(() => "");
+        for (const pair of text.split("&")) {
+                const [k, v] = pair.split("=");
+                if (k) body[decodeURIComponent(k)] = decodeURIComponent(v ?? "");
+        }
+  }
+
+  const apiKey = body.api_key ?? null;
+    const username = body.username ?? null;
+    const action = body.action ?? "";
+
+  if (!validateAuth(apiKey, username)) {
+        return Response.json({ error: "Invalid API Key or Username" }, { status: 401 });
+  }
+
+  // ── ACTION: getservices ──────────────────────────────────────────────────
+  if (action === "getservices") {
+        return Response.json([
+          {
+                    service: "1",
+                    name: "Consultar Líneas Registradas (CURP México)",
+                    type: "Custom",
+                    rate: "0",
+                    min: "1",
+                    max: "1",
+                    dripfeed: false,
+                    refill: false,
+                    cancel: false,
+                    category: "Mexico CURP Lookup",
+          },
+              ]);
+  }
+
+  // ── ACTION: order ────────────────────────────────────────────────────────
+  if (action === "order") {
+        const curp = (body.link ?? body.curp ?? "").trim().toUpperCase();
+
+      if (!curp) {
+              return Response.json({ error: "CURP is required in the 'link' field" }, { status: 400 });
+      }
+
+      if (!validateCURP(curp)) {
+              return Response.json({ error: "Invalid CURP format" }, { status: 400 });
+      }
+
+      const orderId = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+        orders.set(orderId, { status: "pending", createdAt: Date.now() });
+
+      // Run lookup in background
+      runLookup(curp)
+          .then((result) => {
+                    orders.set(orderId, { status: "completed", result, createdAt: Date.now() });
+          })
+          .catch((err) => {
+                    orders.set(orderId, {
+                                status: "error",
+                                result: `Error: ${err?.message ?? err}`,
+                                createdAt: Date.now(),
+                    });
+          });
+
+      // Mark as in progress immediately
+      orders.set(orderId, { status: "inprogress", createdAt: Date.now() });
+
+      return Response.json({ order: orderId });
+  }
+
+  // ── ACTION: status ───────────────────────────────────────────────────────
+  if (action === "status") {
+        const orderId = body.order ?? "";
+        const order = orders.get(orderId);
+
+      if (!order) {
+              return Response.json({ error: "Order not found" }, { status: 404 });
+      }
+
+      return Response.json({
+              order: orderId,
+              status: order.status === "completed"
+                ? "Completed"
+                        : order.status === "error"
+                  ? "Canceled"
+                          : "In progress",
+              charge: "0",
+              start_count: "0",
+              remains: "0",
+              currency: "USD",
+              ...(order.result ? { note: order.result } : {}),
+      });
+  }
+
+  // ── ACTION: balance ──────────────────────────────────────────────────────
+  if (action === "balance") {
+        return Response.json({ balance: "999999", currency: "USD" });
+  }
+
+  return Response.json({ error: "Unknown action" }, { status: 400 });
+}
+
+export async function POST(req: NextRequest) {
+    return handlePost(req);
+}
+
+// Dhru Fusion sometimes uses GET for status checks
+export async function GET(req: NextRequest) {
+    return handlePost(req);
+}

--- a/src/app/api/lookup/route.ts
+++ b/src/app/api/lookup/route.ts
@@ -1,192 +1,198 @@
 import type { NextRequest } from "next/server";
 import {
-  lookupCURPINMobig,
-  lookupCURPINYoMobile,
-  lookupCURPInABIB,
-  lookupCURPInAltanMVNO,
-  lookupCURPInATT,
-  lookupCURPInBeneleit,
-  lookupCURPInDialo,
-  lookupCURPInIENTC,
-  lookupCURPInLogisticaACN,
-  lookupCURPInMirlo,
-  lookupCURPInTelcel,
-  lookupCURPInVinculatulinea,
-  loookupCURPINWeeex,
-  loookupCURPInVirginMobile,
+    lookupCURPINMobig,
+    lookupCURPINYoMobile,
+    lookupCURPInABIB,
+    lookupCURPInAltanMVNO,
+    lookupCURPInATT,
+    lookupCURPInBeneleit,
+    lookupCURPInDialo,
+    lookupCURPInIENTC,
+    lookupCURPInLogisticaACN,
+    lookupCURPInMirlo,
+    lookupCURPInTelcel,
+    lookupCURPInVinculatulinea,
+    loookupCURPINWeeex,
+    loookupCURPInVirginMobile,
 } from "@/lib/providers";
 import { validateCURP } from "@/lib/providers/curp";
-import { checkRateLimit } from "@/lib/rate-limit";
+import { checkRateLimit, validateApiKey } from "@/lib/rate-limit";
 import { stripCURPs } from "@/lib/sanitize";
 import type { LineResult } from "@/types";
 
 const providers: Array<{
-  provider: string;
-  lookupFunction: (curp: string) => Promise<LineResult>;
+    provider: string;
+    lookupFunction: (curp: string) => Promise<LineResult>;
 }> = [
   {
-    provider: "AT&T",
-    lookupFunction: lookupCURPInATT,
+        provider: "AT&T",
+        lookupFunction: lookupCURPInATT,
   },
   {
-    provider: "Telcel",
-    lookupFunction: lookupCURPInTelcel,
+        provider: "Telcel",
+        lookupFunction: lookupCURPInTelcel,
   },
   {
-    provider: "Altan MVNO",
-    lookupFunction: lookupCURPInAltanMVNO,
+        provider: "Altan MVNO",
+        lookupFunction: lookupCURPInAltanMVNO,
   },
   {
-    provider: "ABIB",
-    lookupFunction: lookupCURPInABIB,
+        provider: "ABIB",
+        lookupFunction: lookupCURPInABIB,
   },
   {
-    provider: "Beneleit Móvil",
-    lookupFunction: lookupCURPInBeneleit,
+        provider: "Beneleit Móvil",
+        lookupFunction: lookupCURPInBeneleit,
   },
   {
-    provider: "Dialo",
-    lookupFunction: lookupCURPInDialo,
+        provider: "Dialo",
+        lookupFunction: lookupCURPInDialo,
   },
   {
-    provider: "IENTC",
-    lookupFunction: lookupCURPInIENTC,
+        provider: "IENTC",
+        lookupFunction: lookupCURPInIENTC,
   },
   {
-    provider: "Logistica ACN (FedeGo!, Flash Mobile, Dua)",
-    lookupFunction: lookupCURPInLogisticaACN,
+        provider: "Logistica ACN (FedeGo!, Flash Mobile, Dua)",
+        lookupFunction: lookupCURPInLogisticaACN,
   },
-  // {
-  //   provider: "Mega Móvil",
-  //   lookupFunction: lookupCURPInMegamovil,
-  //   // Disabled: WAF blocks server IP (Attack ID: 20000018)
-  // },
+    // {
+    //   provider: "Mega Móvil",
+    //   lookupFunction: lookupCURPInMegamovil,
+    //   // Disabled: WAF blocks server IP (Attack ID: 20000018)
+    // },
   {
-    provider: "Mirlo",
-    lookupFunction: lookupCURPInMirlo,
+        provider: "Mirlo",
+        lookupFunction: lookupCURPInMirlo,
   },
   {
-    provider: "MoBig",
-    lookupFunction: lookupCURPINMobig,
+        provider: "MoBig",
+        lookupFunction: lookupCURPINMobig,
   },
-  // {
-  //   provider: "Nextor Movil",
-  //   lookupFunction: lookupCURPINNextorMovil,
-  //   // Disabled: rate limit
-  // },
-  // {
-  //   provider: "Sorcel",
-  //   lookupFunction: lookupCURPInSorcel,
-  //   // Disabled: Cloudflare JS challenge blocks server-side requests
-  // },
-  // {
-  //   provider: "TalentoNet (Newww, Red Aguila, Link Móvil)",
-  //   lookupFunction: loookupCURPInTalentoNetMVNO,
-  //   // Disabled: ConnectTimeoutError on core.newww.mx:443
-  // },
+    // {
+    //   provider: "Nextor Movil",
+    //   lookupFunction: lookupCURPINNextorMovil,
+    //   // Disabled: rate limit
+    // },
+    // {
+    //   provider: "Sorcel",
+    //   lookupFunction: lookupCURPInSorcel,
+    //   // Disabled: Cloudflare JS challenge blocks server-side requests
+    // },
+    // {
+    //   provider: "TalentoNet (Newww, Red Aguila, Link Móvil)",
+    //   lookupFunction: loookupCURPInTalentoNetMVNO,
+    //   // Disabled: ConnectTimeoutError on core.newww.mx:443
+    // },
   {
-    provider: "Virgin Mobile",
-    lookupFunction: loookupCURPInVirginMobile,
+        provider: "Virgin Mobile",
+        lookupFunction: loookupCURPInVirginMobile,
   },
-  // {
-  //   provider: "Weex",
-  //   lookupFunction: loookupCURPINWeeex,
-  // },
+    // {
+    //   provider: "Weex",
+    //   lookupFunction: loookupCURPINWeeex,
+    // },
   {
-    provider:
-      "Vinculatulinea (Freedompop/OUI/OXXO CEL/Uber Cel/AhorroCel/Chedraui Móvil/Yobi Telecom)",
-    lookupFunction: lookupCURPInVinculatulinea,
+        provider:
+                "Vinculatulinea (Freedompop/OUI/OXXO CEL/Uber Cel/AhorroCel/Chedraui Móvil/Yobi Telecom)",
+        lookupFunction: lookupCURPInVinculatulinea,
   },
-  // {
-  //   provider: "Yo Mobile",
-  //   lookupFunction: lookupCURPINYoMobile,
-  // },
-];
+    // {
+    //   provider: "Yo Mobile",
+    //   lookupFunction: lookupCURPINYoMobile,
+    // },
+  ];
 
 export async function POST(req: NextRequest) {
-  const ip =
-    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
-  const { allowed, remaining } = checkRateLimit(ip);
+    const authHeader = req.headers.get("authorization");
+    const isApiKeyRequest = validateApiKey(authHeader);
 
-  if (!allowed) {
-    return new Response(JSON.stringify({ error: "Too many requests" }), {
-      status: 429,
-      headers: { "Retry-After": "60" },
-    });
+  // Only apply rate limiting to requests without a valid API Key
+  if (!isApiKeyRequest) {
+        const ip =
+                req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+        const { allowed, remaining } = checkRateLimit(ip);
+
+      if (!allowed) {
+              return new Response(JSON.stringify({ error: "Too many requests" }), {
+                        status: 429,
+                        headers: { "Retry-After": "60" },
+              });
+      }
   }
 
   const { curp } = await req.json();
 
   if (!curp || typeof curp !== "string") {
-    return new Response(
-      JSON.stringify({ error: "CURP is required and must be a string" }),
-      { status: 400 },
-    );
+        return new Response(
+                JSON.stringify({ error: "CURP is required and must be a string" }),
+          { status: 400 },
+              );
   }
 
   const isValidCURP = validateCURP(curp);
 
   if (!isValidCURP) {
-    return new Response(JSON.stringify({ error: "Invalid CURP format" }), {
-      status: 400,
-    });
+        return new Response(JSON.stringify({ error: "Invalid CURP format" }), {
+                status: 400,
+        });
   }
 
   // Use a streaming response to return results as soon as they resolve
   const stream = new ReadableStream({
-    async start(controller) {
-      const encoder = new TextEncoder();
+        async start(controller) {
+                const encoder = new TextEncoder();
 
-      const promises = providers.map((p) =>
-        p
-          .lookupFunction(curp)
-          .then(
-            (result) => ({ provider: p.provider, result }),
-            (error) => {
-              console.error(`Lookup failed for ${p.provider}:`, error);
-              return {
-                provider: p.provider,
-                result: {
-                  company: p.provider,
-                  lines: [],
-                  error: `Lookup failed: ${error.message}`,
-                },
-              };
-            },
-          )
-          .catch((error) => {
-            console.error(
-              `Unexpected error looking up CURP in ${p.provider}:`,
-              error,
-            );
-            return {
-              provider: p.provider,
-              result: {
-                company: p.provider,
-                lines: [],
-                error: "An unexpected error occurred during lookup",
-              },
-            };
-          })
-          .then((response) => {
-            const sanitized = stripCURPs(response);
-            controller.enqueue(
-              encoder.encode(`${JSON.stringify(sanitized)}\n`),
-            );
-          }),
-      );
+          const promises = providers.map((p) =>
+                    p
+                                                   .lookupFunction(curp)
+                                                   .then(
+                                                                 (result) => ({ provider: p.provider, result }),
+                                                                 (error) => {
+                                                                                 console.error(`Lookup failed for ${p.provider}:`, error);
+                                                                                 return {
+                                                                                                   provider: p.provider,
+                                                                                                   result: {
+                                                                                                                       company: p.provider,
+                                                                                                                       lines: [],
+                                                                                                                       error: `Lookup failed: ${error.message}`,
+                                                                                                     },
+                                                                                 };
+                                                                 },
+                                                               )
+                                                   .catch((error) => {
+                                                                 console.error(
+                                                                                 `Unexpected error looking up CURP in ${p.provider}:`,
+                                                                                 error,
+                                                                               );
+                                                                 return {
+                                                                                 provider: p.provider,
+                                                                                 result: {
+                                                                                                   company: p.provider,
+                                                                                                   lines: [],
+                                                                                                   error: "An unexpected error occurred during lookup",
+                                                                                 },
+                                                                 };
+                                                   })
+                                                   .then((response) => {
+                                                                 const sanitized = stripCURPs(response);
+                                                                 controller.enqueue(
+                                                                                 encoder.encode(`${JSON.stringify(sanitized)}\n`),
+                                                                               );
+                                                   }),
+                                               );
 
-      await Promise.allSettled(promises);
-      controller.close();
-    },
+          await Promise.allSettled(promises);
+                controller.close();
+        },
   });
 
   return new Response(stream, {
-    headers: {
-      "Content-Type": "application/x-ndjson",
-      "Cache-Control": "no-cache",
-      Connection: "keep-alive",
-      "X-RateLimit-Remaining": String(remaining),
-    },
+        headers: {
+                "Content-Type": "application/x-ndjson",
+                "Cache-Control": "no-cache",
+                Connection: "keep-alive",
+                "X-RateLimit-Remaining": isApiKeyRequest ? "unlimited" : "see-header",
+        },
   });
 }

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -5,28 +5,46 @@ const MAX_REQUESTS = 10;
 
 // Cleanup old entries every 5 minutes to avoid memory leak
 setInterval(
-  () => {
-    const now = Date.now();
-    for (const [key, entry] of store) {
-      if (entry.resetAt < now) store.delete(key);
-    }
-  },
-  5 * 60_000,
-).unref();
+    () => {
+          const now = Date.now();
+          for (const [key, entry] of store) {
+                  if (entry.resetAt < now) store.delete(key);
+          }
+    },
+    5 * 60_000,
+  ).unref();
 
 export function checkRateLimit(ip: string): { allowed: boolean; remaining: number } {
-  const now = Date.now();
-  const entry = store.get(ip);
+    const now = Date.now();
+    const entry = store.get(ip);
 
   if (!entry || entry.resetAt < now) {
-    store.set(ip, { count: 1, resetAt: now + WINDOW_MS });
-    return { allowed: true, remaining: MAX_REQUESTS - 1 };
+        store.set(ip, { count: 1, resetAt: now + WINDOW_MS });
+        return { allowed: true, remaining: MAX_REQUESTS - 1 };
   }
 
   if (entry.count >= MAX_REQUESTS) {
-    return { allowed: false, remaining: 0 };
+        return { allowed: false, remaining: 0 };
   }
 
   entry.count += 1;
-  return { allowed: true, remaining: MAX_REQUESTS - entry.count };
+    return { allowed: true, remaining: MAX_REQUESTS - entry.count };
+}
+
+/**
+ * Validates an API Key from the Authorization header.
+ * Keys are stored in the env variable API_KEYS as a comma-separated list.
+ * Example: API_KEYS=key1,key2,key3
+ */
+export function validateApiKey(authHeader: string | null): boolean {
+    if (!authHeader) return false;
+    const token = authHeader.startsWith("Bearer ")
+      ? authHeader.slice(7).trim()
+          : authHeader.trim();
+    if (!token) return false;
+    const validKeys = (process.env.API_KEYS ?? "")
+      .split(",")
+      .map((k) => k.trim())
+      .filter(Boolean);
+    return validKeys.includes(token);
 }


### PR DESCRIPTION
## Descripción

Agrega soporte de autenticación por API Key para permitir consultas desde Dhru Fusion y otras integraciones externas.

## Cambios

### `src/lib/rate-limit.ts`
- Se agrega la función exportada `validateApiKey(authHeader)` que valida un token Bearer contra la variable de entorno `API_KEYS` (lista separada por comas).
### `src/app/api/lookup/route.ts`
- Se importa `validateApiKey` desde `@/lib/rate-limit`.
- - Si la petición incluye un header `Authorization: Bearer <clave-válida>`, se omite el rate limit por IP.
- - Si la clave no es válida o no se envía, el comportamiento existente (rate limit por IP) se mantiene igual.
## Configuración necesaria

Agregar la variable de entorno en el servidor de deploy:
```
API_KEYS=tu-clave-secreta
```

Para múltiples claves:
```
API_KEYS=clave1,clave2,clave3
```

## Uso desde Dhru Fusion

| Campo | Valor |
|-------|-------|
| URL | `https://mislineas.com.mx/api/lookup` |
| Método | `POST` |
| Header | `Authorization: Bearer tu-clave-secreta` |
| Content-Type | `application/json` |
| Body | `{"curp": "{{INPUT}}"}` |