### PR TITLE
fix(altanredes): el solver de proof-of-work bloquea el event loop y hace fallar a otros proveedores

### DIFF
--- a/src/lib/providers/altanredes/mvno.ts
+++ b/src/lib/providers/altanredes/mvno.ts
@@ -101,7 +101,7 @@ export async function lookupCURPInAltanMVNO(curp: string): Promise<LineResult> {
   }
 
   const challengeData = await challengeResponse.json();
-  const solution = solveCapChallenge(challengeData);
+  const solution = await solveCapChallenge(challengeData);
 
   const redeemResponse = await fetch(
     "https://rnu.altanredes.com/api/mx/captcha/a92a56476f/redeem",

--- a/src/lib/providers/altanredes/solver.ts
+++ b/src/lib/providers/altanredes/solver.ts
@@ -67,8 +67,21 @@ export function generateChallenges(
   return challenges;
 }
 
-export function solveChallenge(salt: string, target: string): number {
+// Yield to the event loop every this many hashes. Small enough that other
+// providers' sockets are serviced promptly, large enough that the setImmediate
+// round-trip stays negligible against the hashing itself.
+const YIELD_EVERY_HASHES = 4096;
+
+// Upper bound on a single challenge. A difficulty spike should surface as a
+// provider-level error, which route.ts already handles, instead of spinning.
+const SOLVE_TIME_BUDGET_MS = 30_000;
+
+export async function solveChallenge(
+  salt: string,
+  target: string,
+): Promise<number> {
   let nonce = 0;
+  const deadline = Date.now() + SOLVE_TIME_BUDGET_MS;
 
   while (true) {
     const hash = crypto
@@ -81,20 +94,39 @@ export function solveChallenge(salt: string, target: string): number {
     }
 
     nonce++;
+
+    // This loop is CPU-bound, and Node runs it on the same thread that services
+    // every other provider's I/O. Solved synchronously it holds that thread for
+    // as long as the proof-of-work takes, so responses that already arrived from
+    // the other carriers sit unread in their socket buffers and their timeouts
+    // fire late. The symptom is another provider "timing out" while Altan is the
+    // one holding the loop. Handing control back periodically lets that I/O
+    // drain between batches of hashes.
+    if (nonce % YIELD_EVERY_HASHES === 0) {
+      if (Date.now() > deadline) {
+        throw new Error("Altan challenge solve exceeded its time budget");
+      }
+
+      await new Promise((resolve) => setImmediate(resolve));
+    }
   }
 }
 
-export function solveCapChallenge(
+export async function solveCapChallenge(
   challengeResponse: ChallengeInput,
-): ChallengeSolution {
+): Promise<ChallengeSolution> {
   const { challenge, token } = challengeResponse;
   const { c, s, d } = challenge;
 
   const challenges = generateChallenges(token, c, s, d);
 
-  const solutions = challenges.map(([salt, target]) =>
-    solveChallenge(salt, target),
-  );
+  // Sequential on purpose: each solve yields, so running them one after another
+  // keeps the event loop responsive throughout. Solving them concurrently would
+  // not help either, since they all contend for the same single thread.
+  const solutions: number[] = [];
+  for (const [salt, target] of challenges) {
+    solutions.push(await solveChallenge(salt, target));
+  }
 
   return { token, solutions };
 }


### PR DESCRIPTION
Hola — primero, gracias por MisLíneas. Es de esas herramientas que no deberían tener que existir, y me alegra que exista.

Corriéndola self-hosted me topé con timeouts intermitentes en proveedores que no tenían nada de malo. Esta PR arregla la causa de una parte de eso.

## El bug

El captcha de Red Altán es una prueba de trabajo SHA-256, y `solveChallenge` la resuelve en un `while (true)` síncrono. Node corre ese bucle en el mismo hilo que atiende la E/S de todos los demás proveedores, así que mientras muele hashes:

- las respuestas que **ya llegaron** de las otras operadoras se quedan sin leer en el buffer del socket, y
- los temporizadores que deberían disparar sus timeouts se atienden tarde.

El síntoma visible es que **otro** proveedor reporta timeout mientras Altán es el que tiene secuestrado el hilo. El error apunta al inocente. En mi caso AT&T era el que "fallaba" de forma intermitente, y no tenía nada que ver.

## El cambio

- `solveChallenge` cede el control con `setImmediate` cada 4096 hashes, para que la E/S de los demás se drene entre tandas.
- Un presupuesto de 30 s por reto: si la dificultad se dispara, sale como error de proveedor —que `route.ts` ya maneja— en vez de girar para siempre.
- `solveCapChallenge` pasa a `async` y espera cada solve en secuencia. Resolverlos en paralelo no ayudaría: compiten por el mismo hilo.

Solo hay un call site (`altanredes/mvno.ts`), que ahora hace `await`.

## Notas

- No toca el proxy: los proveedores proxeados pasan su `dispatcher` por petición y ese camino queda igual.
- El costo del `setImmediate` es despreciable frente al hashing.
- `tsc --noEmit` no reporta nada nuevo en los archivos tocados.

## Hay más, si te interesa

Encontré otros tres problemas de fiabilidad en la misma sesión de depuración, que dejé fuera de esta PR para que sea revisable de un solo tema:

1. **Sockets keep-alive rancios**: undici conserva un socket ocioso hasta ~600 s, pero `att.com.mx` y la API de Dialo lo cierran a ~30 s. undici escribe la petición sobre una conexión ya muerta y espera el timeout completo. Un `Agent` global con `keepAliveTimeout` corto y `allowH2: false` lo elimina.
2. **Ráfaga de DNS**: disparar todos los proveedores a la vez son ~20 resoluciones simultáneas (A + AAAA); un resolver local devuelve `ENOTFOUND`/`EAI_AGAIN` espurios. Un pool de concurrencia, reintento **solo** de fallos transitorios de DNS (nunca de timeouts, eso amplifica), y pre-calentar el caché al arrancar.
3. **Fetches sin deadline**: varios proveedores no tenían timeout, así que una conexión colgada mantenía abierto el stream completo.

Los tengo aplicados y funcionando, aunque sobre una base más vieja que tu `main`. Si alguno te interesa, los rebaseo y abro PRs por separado — o los dejo así, como tú prefieras.

Escribí la autopsia completa aquí, por si le sirve a alguien: https://rolandoahuja.com/es/notes/captcha-that-froze-the-server
