### PR TITLE
fix(http): undici reutiliza sockets keep-alive que las operadoras ya cerraron

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,38 @@
+// Runs once when the Next server boots, before it handles any request.
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+
+  const { Agent, setGlobalDispatcher } = await import("undici");
+
+  // undici keeps an idle pooled socket for up to ~600s. Several carriers close
+  // theirs far sooner — att.com.mx and Dialo's API drop an idle connection at
+  // around 30s. When the two disagree, undici hands out a socket it believes is
+  // alive, writes the request onto a connection the other end already tore down,
+  // and waits for a reply that can never arrive. The lookup then burns its whole
+  // abort budget and reports a timeout that has nothing to do with the carrier
+  // being slow.
+  //
+  // Evicting idle sockets after 10s keeps us comfortably ahead of the far end,
+  // so the pool never serves a dead connection.
+  //
+  // This sets the *global* dispatcher, which only applies to calls that do not
+  // pass their own. The proxied providers hand `undiciFetch` an explicit
+  // `dispatcher: ProxyAgent`, so their path is untouched; when
+  // RESIDENTIAL_PROXIES is unset and that argument is `undefined`, they fall
+  // back here and get the same protection. Telcel's raw `https` request does not
+  // go through undici at all.
+  setGlobalDispatcher(
+    new Agent({
+      // A single stale HTTP/2 connection is multiplexed, so it takes down every
+      // request riding on it — one dead socket becomes a dozen failures at once.
+      // Over HTTP/1.1 each connection fails on its own.
+      allowH2: false,
+      keepAliveTimeout: 10_000,
+      keepAliveMaxTimeout: 10_000,
+      // Generous on purpose: this is about not reusing dead sockets, not about
+      // cutting slow-but-live handshakes short. The per-provider AbortSignal
+      // remains the hard ceiling.
+      connect: { timeout: 30_000 },
+    }),
+  );
+}


### PR DESCRIPTION
Gracias por mergear el anterior. Aquí va el primero de los tres que mencionaste — el de los sockets keep-alive.

## El bug

undici mantiene un socket ocioso del pool hasta ~600 s. Varias operadoras lo cierran mucho antes: `att.com.mx` y la API de Dialo lo tiran a los ~30 s.

Cuando esos dos números no coinciden, undici entrega un socket que **cree** vivo, escribe la petición encima de una conexión que el otro lado ya desarmó, y se queda esperando una respuesta que no puede llegar. La consulta se come su presupuesto completo de abort y reporta un timeout que no tiene nada que ver con que la operadora esté lenta.

Es el mismo patrón del PR anterior: el error acusa al inocente.

## El cambio

Un `Agent` global de undici en `src/instrumentation.ts` (corre una vez al arrancar el server):

- `keepAliveTimeout` / `keepAliveMaxTimeout` a 10 s → undici desaloja el socket ocioso **antes** que la operadora, así el pool nunca entrega un cadáver.
- `allowH2: false` → una conexión HTTP/2 es multiplexada, así que una sola conexión rancia tumba **todas** las peticiones que van encima; un socket muerto se vuelve una docena de fallos a la vez. Con HTTP/1.1 cada conexión falla sola.
- `connect.timeout` generoso a propósito: esto es sobre no reutilizar sockets muertos, no sobre cortar handshakes lentos pero vivos. El `AbortSignal` por proveedor sigue siendo el techo duro.

## No toca el proxy

`setGlobalDispatcher` solo aplica a llamadas que **no** pasan su propio dispatcher:

- Los providers proxeados le pasan un `ProxyAgent` explícito a `undiciFetch` → ruta intacta.
- Cuando `RESIDENTIAL_PROXIES` no está puesto, `getProxyAgent()` devuelve `undefined` y esas llamadas caen aquí — o sea que en local también quedan protegidas, que es lo deseable.
- La petición cruda de Telcel usa `https` de Node, ni pasa por undici.

## Notas

- `undici` ya es dependencia del proyecto (`^8.5.0`), no agrega nada al `package.json`.
- `instrumentation.ts` es estable en Next 16, no necesita flag experimental.
- `tsc --noEmit` no reporta nada en el archivo nuevo.

Los otros dos (ráfaga de DNS y fetches sin deadline) van en PRs aparte para que cada uno se pueda revisar y revertir solo.
