### PR TITLE
fix(providers): fetches sin deadline dejan colgado el stream completo

### DIFF
--- a/src/lib/data/content.ts
+++ b/src/lib/data/content.ts
@@ -50,3 +50,9 @@ export const ARCO_RIGHTS = [
 
 export const TOTAL_PROVIDERS = 104;
 export const QUERY_TIMEOUT_MS = 15000;
+
+// Hard ceiling on a single provider request. Must stay below the client
+// watchdog (QUERY_TIMEOUT_MS * 2 in useLookup): a stalled carrier should come
+// back as one failed card while the rest of the stream keeps arriving, rather
+// than outliving the abort that kills the whole query.
+export const PROVIDER_TIMEOUT_MS = 25000;

--- a/src/lib/providers/abib.ts
+++ b/src/lib/providers/abib.ts
@@ -1,9 +1,11 @@
+import { PROVIDER_TIMEOUT_MS } from "@/lib/data/content";
 import { stripCURPs } from "@/lib/sanitize";
 import type { LineResult } from "@/types";
 
 export async function lookupCURPInABIB(curp: string): Promise<LineResult> {
   const validationResponse = await fetch(
     `https://erp.abib.com.mx/api/lineas/${curp}`,
+    { signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS) },
   );
 
   if (!validationResponse.ok) {

--- a/src/lib/providers/altanredes/mvno.ts
+++ b/src/lib/providers/altanredes/mvno.ts
@@ -1,3 +1,4 @@
+import { PROVIDER_TIMEOUT_MS } from "@/lib/data/content";
 import crypto from "node:crypto";
 import type { LineResult } from "@/types";
 import { solveCapChallenge } from "./solver";
@@ -74,6 +75,7 @@ export async function lookupCURPInAltanMVNO(curp: string): Promise<LineResult> {
   const challengeResponse = await fetch(
     "https://rnu.altanredes.com/api/mx/captcha/a92a56476f/challenge",
     {
+      signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS),
       referrer: "https://rnu.altanredes.com/consulta",
       method: "POST",
       headers: {
@@ -106,6 +108,7 @@ export async function lookupCURPInAltanMVNO(curp: string): Promise<LineResult> {
   const redeemResponse = await fetch(
     "https://rnu.altanredes.com/api/mx/captcha/a92a56476f/redeem",
     {
+      signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS),
       method: "POST",
       headers: {
         accept: "*/*",
@@ -188,6 +191,7 @@ export async function lookupCURPInAltanMVNO(curp: string): Promise<LineResult> {
   const url = `https://rnu.altanredes.com/_serverFn/be0aebbc40b7f89dcde6ed49a1fdaffb199dd02f87e1de771662e51d6e55c421?payload=${encodeURIComponent(JSON.stringify(validationParams))}`;
 
   const validationResponse = await fetch(url, {
+      signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS),
     headers: {
       accept:
         "application/x-tss-framed, application/x-ndjson, application/json",

--- a/src/lib/providers/beneleit.ts
+++ b/src/lib/providers/beneleit.ts
@@ -1,3 +1,4 @@
+import { PROVIDER_TIMEOUT_MS } from "@/lib/data/content";
 import { stripCURPs } from "@/lib/sanitize";
 import type { LineResult } from "@/types";
 
@@ -6,6 +7,7 @@ export async function lookupCURPInBeneleit(
 ): Promise<LineResult> {
   const validationResponse = await fetch(
     `https://core.beneleit.talentonet.com/api/core/consulta_lineas_vinculacion?curp=${curp}`,
+    { signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS) },
   );
 
   if (validationResponse.status === 404) {

--- a/src/lib/providers/dialo.ts
+++ b/src/lib/providers/dialo.ts
@@ -1,3 +1,4 @@
+import { PROVIDER_TIMEOUT_MS } from "@/lib/data/content";
 import { stripCURPs } from "@/lib/sanitize";
 import type { LineResult } from "@/types";
 
@@ -18,6 +19,7 @@ export async function lookupCURPInDialo(curp: string): Promise<LineResult> {
   const validationResponse = await fetch(
     "https://p737drx1pj.execute-api.us-east-1.amazonaws.com/prod/gestion-lineas",
     {
+      signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS),
       method: "POST",
       headers: validationHeaders,
       body: JSON.stringify(validationBody),

--- a/src/lib/providers/freedompop.ts
+++ b/src/lib/providers/freedompop.ts
@@ -1,3 +1,4 @@
+import { PROVIDER_TIMEOUT_MS } from "@/lib/data/content";
 import { createCipheriv } from "node:crypto";
 import { ProxyAgent, fetch as undiciFetch } from "undici";
 import { getResidentialProxyUrl } from "@/lib/proxy";
@@ -56,6 +57,7 @@ async function fetchSubscriptions(
     "https://vinculatulinea.com/omv-lineas/v1/omv-services/subscriptions-by-curp?pathName=freedompop&apiName=getSubscriptionsbyCURP";
   const auth = Buffer.from("admin:admin123").toString("base64");
   const response = await undiciFetch(url, {
+      signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS),
     method: "GET",
     dispatcher: getProxyAgent(),
     headers: {

--- a/src/lib/providers/ientc.ts
+++ b/src/lib/providers/ientc.ts
@@ -1,3 +1,4 @@
+import { PROVIDER_TIMEOUT_MS } from "@/lib/data/content";
 import { stripCURPs } from "@/lib/sanitize";
 import type { LineResult } from "@/types";
 
@@ -8,6 +9,7 @@ export async function lookupCURPInIENTC(curp: string): Promise<LineResult> {
   const authResponse = await fetch(
     "https://api-iso-prod.ientc.dev/auth/jwt/token",
     {
+      signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS),
       method: "POST",
       headers: {
         Authorization: `Basic N3U4ZThyNjF0OGwwbnRmZ3I5dmozaWhpN2U6a3FvYzNoYzIyZW9nYmVlazdyZWVzNnZqMW81cHFhMzlxcjg4aWVmZ3A3YTRudjd1aXFx`,
@@ -35,6 +37,7 @@ export async function lookupCURPInIENTC(curp: string): Promise<LineResult> {
   const validationResponse = await fetch(
     `https://api-iso-prod.ientc.dev/vinculacion/number/get-phones?curp=${curp}`,
     {
+      signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS),
       headers: {
         Authorization: `Bearer ${accessToken}`,
       },

--- a/src/lib/providers/logisticaacn/mvno.ts
+++ b/src/lib/providers/logisticaacn/mvno.ts
@@ -1,3 +1,4 @@
+import { PROVIDER_TIMEOUT_MS } from "@/lib/data/content";
 import type { LineResult } from "@/types";
 
 const possibleProviders = ["FedeGo!", "Flash Mobile", "Dua"];
@@ -7,6 +8,7 @@ export async function lookupCURPInLogisticaACN(
 ): Promise<LineResult> {
   const validationResponse = await fetch(
     `https://ku.diri.mx/consultaRNU/${curp}`,
+    { signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS) },
   );
 
   if (!validationResponse.ok) {

--- a/src/lib/providers/megamovil.ts
+++ b/src/lib/providers/megamovil.ts
@@ -1,8 +1,10 @@
+import { PROVIDER_TIMEOUT_MS } from "@/lib/data/content";
 import type { LineResult } from "@/types";
 
 export async function lookupCURPInMegamovil(curp: string): Promise<LineResult> {
   const sessionResponse = await fetch(
     "https://consultavinculacion.megamovil.mx",
+    { signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS) },
   );
 
   if (!sessionResponse.ok) {
@@ -17,7 +19,10 @@ export async function lookupCURPInMegamovil(curp: string): Promise<LineResult> {
 
   const validationResponse = await fetch(
     `https://consultavinculacion.megamovil.mx/validaCURP?curp=${curp}`,
-    { headers: { Cookie: cookies } },
+    {
+      signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS),
+      headers: { Cookie: cookies },
+    },
   );
 
   if (!validationResponse.ok) {

--- a/src/lib/providers/mirlo.ts
+++ b/src/lib/providers/mirlo.ts
@@ -1,9 +1,11 @@
+import { PROVIDER_TIMEOUT_MS } from "@/lib/data/content";
 import { stripCURPs } from "@/lib/sanitize";
 import type { LineResult } from "@/types";
 
 export async function lookupCURPInMirlo(curp: string): Promise<LineResult> {
   const validationResponse = await fetch(
     `https://apib.mirlo.com/api/v1/regulation/query/by-curp/${curp}`,
+    { signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS) },
   );
 
   if (!validationResponse.ok) {

--- a/src/lib/providers/mobig.ts
+++ b/src/lib/providers/mobig.ts
@@ -1,3 +1,4 @@
+import { PROVIDER_TIMEOUT_MS } from "@/lib/data/content";
 import { stripCURPs } from "@/lib/sanitize";
 import type { LineResult } from "@/types";
 
@@ -11,6 +12,7 @@ const UA =
 export async function lookupCURPINMobig(curp: string): Promise<LineResult> {
   // Step 1: GET session page to obtain cookies and CSRF token
   const sessionResponse = await fetch(SESSION_URL, {
+      signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS),
     method: "GET",
     headers: {
       Accept:
@@ -66,6 +68,7 @@ export async function lookupCURPINMobig(curp: string): Promise<LineResult> {
 
   // Step 2: POST search
   const searchResponse = await fetch(SEARCH_URL, {
+      signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS),
     method: "POST",
     headers: {
       Accept: "application/json",

--- a/src/lib/providers/nextor-movil.ts
+++ b/src/lib/providers/nextor-movil.ts
@@ -1,3 +1,4 @@
+import { PROVIDER_TIMEOUT_MS } from "@/lib/data/content";
 import { stripCURPs } from "@/lib/sanitize";
 import type { LineResult } from "@/types";
 
@@ -7,6 +8,7 @@ export async function lookupCURPINNextorMovil(
   const authResponse = await fetch(
     "https://vinculacion.nextormovil.mx/api/consulta/iniciar",
     {
+      signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS),
       method: "POST",
     },
   );
@@ -49,6 +51,7 @@ export async function lookupCURPINNextorMovil(
   const validationResponse = await fetch(
     "https://vinculacion.nextormovil.mx/api/consulta/pre-check",
     {
+      signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS),
       method: "POST",
       headers: validationHeaders,
       body: JSON.stringify(validationBody),

--- a/src/lib/providers/sorcel.ts
+++ b/src/lib/providers/sorcel.ts
@@ -1,3 +1,4 @@
+import { PROVIDER_TIMEOUT_MS } from "@/lib/data/content";
 import type { LineResult } from "@/types";
 
 export async function lookupCURPInSorcel(curp: string): Promise<LineResult> {
@@ -7,6 +8,7 @@ export async function lookupCURPInSorcel(curp: string): Promise<LineResult> {
   const validationResponse = await fetch(
     "https://www.soriup.mx/consultaR.asp",
     {
+      signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS),
       method: "POST",
       body: vallidationFormData,
     },

--- a/src/lib/providers/talentonet/mvno.ts
+++ b/src/lib/providers/talentonet/mvno.ts
@@ -1,3 +1,4 @@
+import { PROVIDER_TIMEOUT_MS } from "@/lib/data/content";
 import { ProxyAgent, fetch as undiciFetch } from "undici";
 import { getResidentialProxyUrl } from "@/lib/proxy";
 import { stripCURPs } from "@/lib/sanitize";
@@ -11,7 +12,10 @@ export async function loookupCURPInTalentoNetMVNO(
   const proxyUrl = getResidentialProxyUrl();
   const validationResponse = await undiciFetch(
     `https://core.newww.mx/api/core/consulta_lineas_vinculacion?curp=${curp}`,
-    { dispatcher: proxyUrl ? new ProxyAgent(proxyUrl) : undefined },
+    {
+      signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS),
+      dispatcher: proxyUrl ? new ProxyAgent(proxyUrl) : undefined,
+    },
   );
 
   if (validationResponse.status === 404) {

--- a/src/lib/providers/virgin-mobile.ts
+++ b/src/lib/providers/virgin-mobile.ts
@@ -1,3 +1,4 @@
+import { PROVIDER_TIMEOUT_MS } from "@/lib/data/content";
 import type { LineResult } from "@/types";
 
 export async function loookupCURPInVirginMobile(
@@ -11,6 +12,7 @@ export async function loookupCURPInVirginMobile(
   const validationResponse = await fetch(
     "https://www.virginmobile.mx/api/v1/public/consulta-linea/findMsisdn",
     {
+      signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS),
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
El segundo de los tres: los fetches sin deadline.

## El bug

La mayoría de las peticiones a proveedores no tenían timeout. Una conexión que se atora sin cerrarse deja a ese proveedor colgado para siempre — y como el stream NDJSON solo cierra cuando **todos** terminan, una sola operadora atorada mantiene abierta la respuesta completa.

Desde el lado del usuario no se ve como "esta operadora falló": se ve como una consulta que nunca termina.

## El cambio

`signal: AbortSignal.timeout(PROVIDER_TIMEOUT_MS)` en las 20 llamadas que no lo tenían, repartidas en 14 proveedores.

La constante vive junto a `QUERY_TIMEOUT_MS` en `src/lib/data/content.ts`, y está **a propósito por debajo del watchdog del cliente** (`QUERY_TIMEOUT_MS * 2` en `useLookup`). Ese orden importa: si el techo del servidor fuera mayor, nunca se dispararía — el cliente abortaría la consulta entera antes, que es justo el comportamiento que queremos evitar. Dejé el porqué escrito en un comentario junto a la constante para que no se desincronice si alguien mueve uno de los dos números.

## Dos archivos quedan fuera, a propósito

- **`att.ts`** — sus `fetch` corren dentro de `page.evaluate`, o sea en el contexto del navegador. Un `AbortSignal` de Node no aplica ahí, ni siquiera se serializa dentro del closure.
- **`telcel.ts`** — usa `node:https` directo y ya trae su propio `timeout`. No tiene el bug.

## Sobre el diff

Está acotado a mis líneas: 46 inserciones, 2 borrados. Los dos borrados son objetos de opciones que estaban en una sola línea y tuvieron que expandirse para que cupiera la propiedad nueva.

**No corrí `biome format` sobre los archivos.** Lo intenté al principio y reformateó cosas preexistentes que no tienen nada que ver con este cambio (`dialo.ts` sobre todo), así que reverti y formateé la inserción a mano para que el diff sea solo esto. Si prefieres que corra el formateador sobre el árbol completo, mejor en un commit aparte.

`tsc --noEmit` no reporta nada nuevo.

Falta el tercero (la ráfaga de DNS), va en su propia PR.
