### PR TITLE
fix(lookup): el abanico de proveedores satura el resolver y reporta operadoras sanas como fallidas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,10 @@ FROM node:24-bookworm-slim AS production
 
 ENV NODE_ENV=production
 ENV CHROME_PATH=/usr/bin/chromium
+# getaddrinfo() runs on libuv's thread pool, which defaults to 4 threads. A
+# lookup resolves a dozen carrier hosts at once, so name resolution would queue
+# four at a time behind itself before a single request leaves the process.
+ENV UV_THREADPOOL_SIZE=64
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     chromium \

--- a/src/app/api/lookup/route.ts
+++ b/src/app/api/lookup/route.ts
@@ -24,6 +24,24 @@ import { checkRateLimit } from "@/lib/rate-limit";
 import { stripCURPs } from "@/lib/sanitize";
 import type { LineResult } from "@/types";
 
+// Firing every provider at once means a dozen simultaneous name resolutions —
+// each host needs both an A and an AAAA record. Under that burst a resolver can
+// start answering ENOTFOUND / EAI_AGAIN for hosts that are perfectly reachable:
+// a "not right now" indistinguishable from "no such host". Capping how many
+// lookups are in flight keeps it out of that state. Raise it if your resolver
+// copes fine — the results still stream in as each provider settles.
+const LOOKUP_CONCURRENCY = 5;
+
+// Retry only failures a warm cache fixes. Deliberately NOT timeouts: a request
+// that already spent its full budget is saturation or a dead socket, never a
+// name-resolution hiccup, and retrying it twice turns one slow lookup into a
+// multi-minute one.
+const TRANSIENT_ERROR = /fetch failed|ENOTFOUND|EAI_AGAIN/i;
+const MAX_RETRIES = 2;
+const RETRY_BASE_DELAY_MS = 300;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 const providers: Array<{
   provider: string;
   lookupFunction: (curp: string) => Promise<LineResult | LineResult[]>;
@@ -149,55 +167,67 @@ export async function POST(req: NextRequest) {
     async start(controller) {
       const encoder = new TextEncoder();
 
-      const promises = providers.map((p) =>
-        p
-          .lookupFunction(curp)
-          .then(
-            (result) => {
-              const results = Array.isArray(result) ? result : [result];
-              return results.map((r) => ({ provider: p.provider, result: r }));
-            },
-            (error) => {
-              console.error(`Lookup failed for ${p.provider}:`, error);
-              return [
-                {
-                  provider: p.provider,
-                  result: {
-                    company: p.provider,
-                    lines: [],
-                    error: `Lookup failed: ${error.message}`,
-                  },
-                },
-              ];
-            },
-          )
-          .catch((error) => {
-            console.error(
-              `Unexpected error looking up CURP in ${p.provider}:`,
-              error,
+      const lookupWithRetry = async (p: (typeof providers)[number]) => {
+        for (let attempt = 0; ; attempt += 1) {
+          try {
+            const result = await p.lookupFunction(curp);
+            const results = Array.isArray(result) ? result : [result];
+
+            // A transient network failure usually comes back as a populated
+            // `error` field rather than a throw, so it has to be caught here too.
+            const transient = results.some(
+              (r) => r?.error && TRANSIENT_ERROR.test(r.error),
             );
+            if (transient && attempt < MAX_RETRIES) {
+              await sleep(RETRY_BASE_DELAY_MS * (attempt + 1));
+              continue;
+            }
+
+            return results.map((r) => ({ provider: p.provider, result: r }));
+          } catch (error) {
+            const message =
+              error instanceof Error ? error.message : "Unknown error";
+
+            if (TRANSIENT_ERROR.test(message) && attempt < MAX_RETRIES) {
+              await sleep(RETRY_BASE_DELAY_MS * (attempt + 1));
+              continue;
+            }
+
+            console.error(`Lookup failed for ${p.provider}:`, error);
             return [
               {
                 provider: p.provider,
                 result: {
                   company: p.provider,
                   lines: [],
-                  error: "An unexpected error occurred during lookup",
+                  error: `Lookup failed: ${message}`,
                 },
               },
             ];
-          })
-          .then((responses) => {
-            for (const response of responses) {
-              const sanitized = stripCURPs(response);
-              controller.enqueue(
-                encoder.encode(`${JSON.stringify(sanitized)}\n`),
-              );
-            }
-          }),
-      );
+          }
+        }
+      };
 
-      await Promise.allSettled(promises);
+      const queue = [...providers];
+      const worker = async () => {
+        for (;;) {
+          const p = queue.shift();
+          if (!p) return;
+
+          for (const response of await lookupWithRetry(p)) {
+            controller.enqueue(
+              encoder.encode(`${JSON.stringify(stripCURPs(response))}\n`),
+            );
+          }
+        }
+      };
+
+      await Promise.all(
+        Array.from(
+          { length: Math.min(LOOKUP_CONCURRENCY, providers.length) },
+          worker,
+        ),
+      );
       controller.close();
     },
   });


### PR DESCRIPTION
El tercero y último de los que mencionaste.

## El bug

Disparar todos los proveedores de golpe son ~una docena de resoluciones DNS simultáneas — cada host necesita registro A y AAAA. Bajo esa ráfaga, un resolver empieza a devolver `ENOTFOUND` / `EAI_AGAIN` para hosts que están perfectamente alcanzables. Es un "ahorita no" que el código no puede distinguir de "ese host no existe", así que una operadora sana se reporta como fallida.

La pista que lo delata: pega mucho más en la primera consulta después de un arranque en frío. Eso es firma de caché, no de red.

## El cambio

Tres partes, una sola causa:

1. **Pool de concurrencia** (`LOOKUP_CONCURRENCY`) en lugar del abanico sin límite, para que al resolver nunca le pidan una docena de respuestas a la vez. Los resultados siguen llegando en streaming conforme cada proveedor termina — el comportamiento visible no cambia.
2. **Reintento solo de fallos transitorios de DNS/conexión, y explícitamente NO de timeouts.** Esa distinción es el fix completo: una petición que ya gastó todo su presupuesto es saturación o un socket muerto, nunca un tropiezo de resolución, y reintentarla dos veces convierte una consulta lenta en una de varios minutos.
3. **`UV_THREADPOOL_SIZE` en la imagen**, porque `getaddrinfo()` corre sobre el thread pool de libuv, que trae **4** hilos por defecto. Sin eso, la resolución se forma de cuatro en cuatro antes de que salga una sola petición del proceso.

El reintento también contempla los proveedores que devuelven arreglo: un fallo transitorio suele llegar como campo `error` poblado y no como throw, así que se revisa también en la ruta de éxito.

## Lo que dejé fuera a propósito

En mi rama tengo además un **pre-calentamiento de DNS bloqueante** al arrancar, que resuelve todos los hosts en lotes chicos antes de aceptar la primera petición. No lo incluyo aquí por dos razones:

- Mi evidencia viene de un `systemd-resolved` local. Ustedes corren en Docker con otro resolver, y **no lo he medido en ese entorno** — no quiero afirmar que tienen el problema donde no lo comprobé.
- Requiere una lista de hosts hardcodeada que se va a desincronizar cada vez que entre o salga un proveedor.

Si te interesa, lo mando aparte y lo discutimos; pero me parecía peor meterlo de contrabando aquí.

## Notas

- `LOOKUP_CONCURRENCY` es una constante nombrada justamente para que la subas si tu resolver aguanta bien. Con 12 proveedores activos, 5 concurrentes agrega algo de latencia total a cambio de que no haya falsos negativos.
- `tsc --noEmit` no reporta nada nuevo. (Los dos imports sin usar de `route.ts` y el `any` implícito de `att.ts` ya venían de antes; no los toqué para no mezclar temas.)
